### PR TITLE
Fixing query string encoding in Resolver

### DIFF
--- a/src/core/Resolver.ts
+++ b/src/core/Resolver.ts
@@ -72,7 +72,7 @@ export abstract class Resolver<Aux, Data> {
             return "";
         }
 
-        const variable = `${key}=${encodeURI(value)}`;
+        const variable = `${key}=${encodeURIComponent(value)}`;
         return variable;
     }
 }


### PR DESCRIPTION
The bug affects query string parameters like URLs.